### PR TITLE
[REVIEW] Match last matching stub

### DIFF
--- a/lib/vanilli/stub-registry.js
+++ b/lib/vanilli/stub-registry.js
@@ -241,7 +241,7 @@ exports.create = function (config) {
             });
 
             if (matchingStubs.length > 0) {
-                match = matchingStubs.reduce(function (currentWinner, candidate) {
+                match = matchingStubs.reverse().reduce(function (currentWinner, candidate) {
                     if (safePriorityFor(candidate) < safePriorityFor(currentWinner)) {
                         return candidate;
                     }

--- a/test/e2e/vanilli-test.js
+++ b/test/e2e/vanilli-test.js
@@ -69,6 +69,19 @@ describe('Vanilli', function () {
             });
     });
 
+    it('serves up the last matched stub, rather than the first', function (done) {
+        vanilli.stub(
+            vanilli.onGet("/my/url").respondWith(123),
+            vanilli.onGet("/my/url").respondWith(234)
+        );
+
+        client.get("/my/url")
+            .end(function (err, res) {
+                expect(res).to.have.status(234);
+                done();
+            });
+    });
+
     it('adds headers from matching stub to response', function (done) {
         vanilli.stub(
             vanilli.onGet(dummyUrl).respondWith(dummyStatus, {

--- a/test/unit/stub-registry-test.js
+++ b/test/unit/stub-registry-test.js
@@ -632,7 +632,7 @@ describe('The stub registry', function () {
             expect(registry.findMatchFor({ path: path("another/url"), method: 'GET' })).to.not.exist;
         });
 
-        it('matches the first matching stub', function () {
+        it('matches the last matching stub', function () {
             registry.addStub({
                 criteria: {
                     url: dummyUrl
@@ -650,7 +650,7 @@ describe('The stub registry', function () {
                 }
             });
 
-            expect(registry.findMatchFor({ path: path(dummyPath), method: 'GET' }).response.status).to.equal(123);
+            expect(registry.findMatchFor({ path: path(dummyPath), method: 'GET' }).response.status).to.equal(456);
         });
 
         it('matches the highest priority (i.e. lowest number) matching stub', function () {
@@ -676,7 +676,7 @@ describe('The stub registry', function () {
             expect(registry.findMatchFor({ path: path(dummyPath), method: 'GET' }).response.status).to.equal(456);
         });
 
-        it('matches the first matching stub when priorities match', function () {
+        it('matches the last matching stub when priorities match', function () {
             registry.addStub({
                 criteria: {
                     url: dummyUrl
@@ -696,7 +696,7 @@ describe('The stub registry', function () {
                 }
             });
 
-            expect(registry.findMatchFor({ path: path(dummyPath), method: 'GET' }).response.status).to.equal(123);
+            expect(registry.findMatchFor({ path: path(dummyPath), method: 'GET' }).response.status).to.equal(456);
         });
 
         it('assumes a priority of 0 for stubs without an explicit priority', function () {


### PR DESCRIPTION
With our cukes, we tend to set the same vanilli stub multiple times with different responses. It is usually the last defined stub that we'd like to match, rather than the first.