### PR TITLE
[WIP] Custom Content-Types

### DIFF
--- a/lib/vanilli/stub-registry.js
+++ b/lib/vanilli/stub-registry.js
@@ -131,6 +131,10 @@ exports.create = function (config) {
                 return (typeof thing === 'object') ? JSON.stringify(thing) : thing;
             }
 
+            function bufferAsString(thing) {
+                return (thing instanceof Buffer) ? thing.toString() : thing;
+            }
+
             function criteriaMatchesPrimitive (criteria, value) {
                 return (typeof value !== 'undefined') &&
                         (criteria.regex && value.match(criteria.regex)) ||
@@ -143,7 +147,7 @@ exports.create = function (config) {
                         log.debug("REJECTED stub '" + stub.id + "' on body [Expected: '" + stub.criteria.body + "'; Actual: " + request.body + "]");
                         return false;
 
-                    } else if (objectAsString(stub.criteria.body) !== objectAsString(request.body)) {
+                    } else if (objectAsString(stub.criteria.body) !== objectAsString(bufferAsString(request.body))) {
                         log.debug("REJECTED stub '" + stub.id + "' on body [Expected: '" + stub.criteria.body + "'; Actual: " + request.body + "]");
                         return false;
 

--- a/test/e2e/vanilli-test.js
+++ b/test/e2e/vanilli-test.js
@@ -251,8 +251,9 @@ describe('Vanilli', function () {
 
     it('can parse custom content-types for request and responses', function (done) {
         vanilli.stub(
-            vanilli.onPost(dummyUrl, { body: { a: 'A' }, contentType: 'application/vnd.custom+json' }).respondWith(123),
-            vanilli.onPost(dummyUrl, { body: { b: 'B' }, contentType: 'application/vnd.custom+json' }).respondWith(234)
+            vanilli.onPost(dummyUrl, { body: { a: 'A' }, contentType: 'application/vnd.custom+json' })
+                .respondWith(123, { contentType: "application/vnd.custom2+json"
+            })
         );
 
         client.post(dummyUrl)
@@ -260,7 +261,7 @@ describe('Vanilli', function () {
             .send(JSON.stringify({ a: 'A' }))
             .end(function (err, res) {
                 expect(res).to.have.status(123);
-                expect(res.header['content-type']).to.equal('application/vnd.custom+json');
+                expect(res.header['content-type']).to.equal('application/vnd.custom2+json');
                 done();
             });
     });

--- a/test/e2e/vanilli-test.js
+++ b/test/e2e/vanilli-test.js
@@ -249,6 +249,22 @@ describe('Vanilli', function () {
             });
     });
 
+    it('can parse custom content-types for request and responses', function (done) {
+        vanilli.stub(
+            vanilli.onPost(dummyUrl, { body: { a: 'A' }, contentType: 'application/vnd.custom+json' }).respondWith(123),
+            vanilli.onPost(dummyUrl, { body: { b: 'B' }, contentType: 'application/vnd.custom+json' }).respondWith(234)
+        );
+
+        client.post(dummyUrl)
+            .type('application/vnd.custom+json')
+            .send(JSON.stringify({ a: 'A' }))
+            .end(function (err, res) {
+                expect(res).to.have.status(123);
+                expect(res.header['content-type']).to.equal('application/vnd.custom+json');
+                done();
+            });
+    });
+
     describe('static content', function () {
         it('is served if request meets criteria of static filter', function (done) {
             client.get('/something.html')


### PR DESCRIPTION
### Overview

The aim of this pull request is for Vanilli to be able to parse custom `Content-Type` headers for both the request and response.

Our application (`mixrad-app`) uses Vanilli for its acceptance tests. The application adheres to a solid REST API where we use custom `Content-Type`s for the request and responses, and up to now Vanilli has handled this fine, but we've ran into a problem trying to match a stub on a `POST`'s `body`.

For example, say we define two stubs that expect a `POST` to the *same* url, but with different request bodies. When the `Content-Type` is `application/json`, Vanilli (well, restify) can handle this fine. However, with a custom `Content-Type` restify defaults to sticking the request body into a `Buffer`: https://github.com/mcavage/node-restify/blob/master/lib/plugins/body_reader.js#L22-L40.

When the stub registry starts trying to match a request against the different criteria, it runs into a problem with the `bodiesMatch` method. Adding a couple of `console.log`s to the beginning of the function like:

```patch
     function bodiesMatch (request, stub) {
+        console.log(stub.criteria.body);
+        console.log(request.body);
         ...
     }
```

gives:

```
{ some: { data: 'that is fine' }}
<Buffer 1a 2b 3c ...>
```

which means the stub will never match.

We could simply add a conditional into the `bodiesMatch` method to check for type `Buffer`, and then decode accordingly but I don't believe this is the right solution. It would be nice to add some middleware (`server.use()`) to extend restify to be able to handle this type of behaviour.

### Some things I've looked into

- restify `formatters` (http://mcavage.me/node-restify/#content-negotiation) – This is a good way to edit the *response* based off the request, but I believe it's different from what we need.
- expressjs' `body-parser` (https://github.com/expressjs/body-parser) – This is a standalone module and it does integrate with restify's middleware correctly too. Has a nice API such as: `server.use(bodyParser.json({ type: 'application/*+json' }))` to parse the provided type (wildcard matched) as JSON. Could do with investigating this a little more.
