### PR TITLE
[REVIEW] Multiple captures

### DIFF
--- a/lib/vanilli.js
+++ b/lib/vanilli.js
@@ -185,6 +185,15 @@ function Vanilli(config) {
     };
 
     /**
+     * Retrieves all the captures stored against the specified capture id.
+     *
+     * @returns Array of captures
+     */
+    this.getCaptures = function (captureId) {
+        return registry.getCaptures(captureId) || [];
+    };
+
+    /**
      * Creates a stub with criteria based on an HTTP GET for the specified relative URL.
      *
      * @returns The new stub definition

--- a/lib/vanilli/stub-registry.js
+++ b/lib/vanilli/stub-registry.js
@@ -72,12 +72,16 @@ exports.create = function (config) {
         function storeCapture(captureId, request) {
             log.info("CAPTURED request as capture with id '" + captureId + "'.");
 
-            captures[captureId] = {
+            if (!captures[captureId]) {
+                captures[captureId] = [];
+            }
+
+            captures[captureId].push({
                 body: request.body,
                 headers: request.headers,
                 query: request.query,
                 contentType: request.contentType()
-            };
+            });
         }
 
         this.addStub = function (stub) {
@@ -267,6 +271,10 @@ exports.create = function (config) {
         };
 
         this.getCapture = function (captureId) {
+            return _.last(this.getCaptures(captureId));
+        };
+
+        this.getCaptures = function (captureId) {
             return captures[captureId];
         };
 

--- a/test/e2e/vanilli-test.js
+++ b/test/e2e/vanilli-test.js
@@ -348,74 +348,108 @@ describe('Vanilli', function () {
 
 
     describe('captures', function () {
-        it('contain request entity itself', function (done) {
+        describe('getting the most recent capture', function () {
+            it('contain request entity itself', function (done) {
+                var captureId = "mycapture";
+
+                vanilli.stub(
+                    vanilli.onPost("/my/url")
+                        .respondWith(dummyStatus)
+                        .capture(captureId)
+                );
+
+                client.post('/my/url')
+                    .send({ some: "content" })
+                    .end(function () {
+                        var capture = vanilli.getCapture(captureId);
+                        expect(capture.body).to.deep.equal({ some: "content" });
+                        expect(capture.contentType).to.deep.equal("application/json");
+
+                        done();
+                    });
+            });
+
+            it('contain request headers', function (done) {
+                var captureId = "mycapture";
+
+                vanilli.stub(
+                    vanilli.onPost("/my/url")
+                        .respondWith(dummyStatus)
+                        .capture(captureId)
+                );
+
+                client.post('/my/url')
+                    .set('My-Header', "myvalue")
+                    .send("somecontent")
+                    .end(function () {
+                        client.get('/_vanilli/captures/' + captureId)
+                            .end(function () {
+                                var capture = vanilli.getCapture(captureId);
+
+                                expect(capture.headers["my-header"]).to.equal("myvalue");
+
+                                done();
+                            });
+                    });
+            });
+
+            it('contain query params', function (done) {
+                var captureId = "mycapture";
+
+                vanilli.stub(
+                    vanilli.onPost("/my/url")
+                        .respondWith(dummyStatus)
+                        .capture(captureId)
+                );
+
+                client.post('/my/url?param1=value1&param2=value2')
+                    .send("somecontent")
+                    .end(function () {
+                        client.get('/_vanilli/captures/' + captureId)
+                            .end(function () {
+                                var capture = vanilli.getCapture(captureId);
+
+                                expect(capture.query).to.deep.equal({
+                                    param1: "value1",
+                                    param2: "value2"
+                                });
+
+                                done();
+                            });
+                    });
+            });
+        });
+    });
+
+    describe('getting all captures for a given capture id', function () {
+        it('returns an empty array if no captures', function () {
+            expect(vanilli.getCaptures('foo')).to.eql([]);
+        });
+
+        it('returns an array of captures', function (done) {
             var captureId = "mycapture";
 
             vanilli.stub(
                 vanilli.onPost("/my/url")
-                    .respondWith(dummyStatus)
+                    .respondWith(dummyStatus, { times: 2 })
                     .capture(captureId)
             );
 
             client.post('/my/url')
                 .send({ some: "content" })
+                .end();
+            client.post('/my/url')
+                .send({ some: "other content" })
                 .end(function () {
-                    var capture = vanilli.getCapture(captureId);
-                    expect(capture.body).to.deep.equal({ some: "content" });
-                    expect(capture.contentType).to.deep.equal("application/json");
+                    var captures = vanilli.getCaptures(captureId);
+
+                    expect(captures).to.have.length(2);
+                    expect(captures[0].body).to.deep.equal({ some: "content" });
+                    expect(captures[1].body).to.deep.equal({ some: "other content" });
 
                     done();
                 });
         });
 
-        it('contain request headers', function (done) {
-            var captureId = "mycapture";
-
-            vanilli.stub(
-                vanilli.onPost("/my/url")
-                    .respondWith(dummyStatus)
-                    .capture(captureId)
-            );
-
-            client.post('/my/url')
-                .set('My-Header', "myvalue")
-                .send("somecontent")
-                .end(function () {
-                    client.get('/_vanilli/captures/' + captureId)
-                        .end(function () {
-                            var capture = vanilli.getCapture(captureId);
-
-                            expect(capture.headers["my-header"]).to.equal("myvalue");
-
-                            done();
-                        });
-                });
-        });
-
-        it('contain query params', function (done) {
-            var captureId = "mycapture";
-
-            vanilli.stub(
-                vanilli.onPost("/my/url")
-                    .respondWith(dummyStatus)
-                    .capture(captureId)
-            );
-
-            client.post('/my/url?param1=value1&param2=value2')
-                .send("somecontent")
-                .end(function () {
-                    client.get('/_vanilli/captures/' + captureId)
-                        .end(function () {
-                            var capture = vanilli.getCapture(captureId);
-
-                            expect(capture.query).to.deep.equal({
-                                param1: "value1",
-                                param2: "value2"
-                            });
-
-                            done();
-                        });
-                });
-        });
     });
 });

--- a/test/unit/stub-registry-test.js
+++ b/test/unit/stub-registry-test.js
@@ -877,6 +877,41 @@ describe('The stub registry', function () {
             expect(registry.getCapture('mycapture').body).to.deep.equal(body);
             expect(registry.getCapture('mycapture').contentType).to.equal(contentType);
         });
+
+        it('can capture multiple requests', function () {
+            var contentType = "my/contenttype";
+
+            registry.addStub({
+                criteria: {
+                    method: 'POST',
+                    url: "/my/url"
+                },
+                response: dummyResponse,
+                captureId: "mycapture"
+            });
+
+            registry.findMatchFor({
+                path: path("my/url"),
+                method: 'POST',
+                body: { some: 'body' },
+                contentType: function () {
+                    return contentType;
+                }
+            });
+
+            registry.findMatchFor({
+                path: path("my/url"),
+                method: 'POST',
+                body: { other: 'body' },
+                contentType: function () {
+                    return contentType;
+                }
+            });
+
+            expect(registry.getCaptures('mycapture')).to.have.length(2);
+            expect(registry.getCaptures('mycapture')[0].body).to.deep.equal({ some: 'body' });
+            expect(registry.getCaptures('mycapture')[1].body).to.deep.equal({ other: 'body' });
+        });
     });
 });
 


### PR DESCRIPTION
Extend registry capturer to store all captures, not just the most recent.

- adds a new .getCaptures() method to retrieve an array of captures for
  a given capture id.