### PR TITLE
Allow running Vanilli as a standalone server

### DIFF
--- a/bin/vanilli
+++ b/bin/vanilli
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var path = require('path'),
+    fs = require('fs'),
+    argv = require('optimist')
+        .usage('Usage: $0 --port [num] --logLevel [debug|info|warn|error]')
+        .demand('port')
+        .describe('port', 'Port to run Vanilli on')
+        .describe('logLevel', 'Log level')
+        .default('logLevel', 'info')
+        .argv,
+    port = argv.port,
+    logLevel = argv.logLevel,
+    dir = path.resolve(process.cwd(), 'node_modules', 'vanilli', 'lib');
+
+if (!fs.existsSync(dir)) {
+  dir = path.join('..', 'lib');
+}
+
+require(path.join(dir, 'vanilli'))
+    .init({ logLevel: logLevel })
+    .listen(port);

--- a/bin/vanilli
+++ b/bin/vanilli
@@ -8,9 +8,17 @@ var path = require('path'),
         .describe('port', 'Port to run Vanilli on')
         .describe('logLevel', 'Log level')
         .default('logLevel', 'info')
+        .describe('staticRoot', 'Root for static content')
+        .describe('staticInclude', 'Comma-separated list of globs for inclusion as static content')
+        .describe('staticExclude', 'Comma-separated list of globs for exclusion as static content')
+        .describe('staticDefault', 'Static content default document')
         .argv,
     port = argv.port,
     logLevel = argv.logLevel,
+    staticRoot = argv.staticRoot,
+    staticDefault = argv.staticDefault,
+    staticInclude = argv.staticInclude ? argv.staticInclude.split(",") : null,
+    staticExclude = argv.staticExclude ? argv.staticExclude.split(",") : null,
     dir = path.resolve(process.cwd(), 'node_modules', 'vanilli', 'lib');
 
 if (!fs.existsSync(dir)) {
@@ -18,5 +26,12 @@ if (!fs.existsSync(dir)) {
 }
 
 require(path.join(dir, 'vanilli'))
-    .init({ logLevel: logLevel })
+    .init({ logLevel: logLevel,
+            static: {
+                root: staticRoot,
+                default: staticDefault,
+                include: staticInclude,
+                exclude: staticExclude
+            }
+     })
     .listen(port);

--- a/lib/vanilli/server.js
+++ b/lib/vanilli/server.js
@@ -7,23 +7,27 @@ var restify = require('restify'),
 
 exports.start = function (config) {
     function createStaticServer(config) {
-        if (config.static) {
-            return  {
+        if (config.static && config.static.root) {
+            var serverConfig = {
                 serve: restify.serveStatic({
                     directory: config.static.root,
                     "default": config.static.default || "index.html"
                 }),
-                include: config.static.include || [],
-                exclude: config.static.exclude || []
+                include: config.static.include,
+                exclude: config.static.exclude
             };
+
+            log.debug("Serving up static content with configuration", config.static);
+
+            return serverConfig;
         }
     }
+
+    log = config.log;
 
     var port = config.port,
         stubRegistry = config.registry,
         staticServer = createStaticServer(config);
-
-    log = config.log;
 
     if (!port) {
         throw new Error("Port must be specified.");
@@ -182,7 +186,7 @@ exports.start = function (config) {
 
                     return ((url === "/") || (url.length === 0)) ||
                         (((staticServer.include.length === 0) || (staticServer.include.some(matchesUrl))) &&
-                         ((staticServer.exclude.length === 0) || (!staticServer.exclude.some(matchesUrl))));
+                            ((staticServer.exclude.length === 0) || (!staticServer.exclude.some(matchesUrl))));
                 }
             }
 

--- a/lib/vanilli/server.js
+++ b/lib/vanilli/server.js
@@ -115,13 +115,6 @@ exports.start = function (config) {
             }
         }
 
-        function createCorsSupportingOptsMethodFor(url) {
-            server.opts(url, function (request, response, next) {
-                response.send(200);
-                next();
-            });
-        }
-
         log.info("Vanilli Server started on port " + port + ".");
 
         server.get('_vanilli/ping', function (request, response, next) {
@@ -129,14 +122,12 @@ exports.start = function (config) {
             return next();
         });
 
-        createCorsSupportingOptsMethodFor('_vanilli/stubs');
         server.del('_vanilli/stubs', function (request, response, next) {
             stubRegistry.clear();
             response.send(200);
             next();
         });
 
-        createCorsSupportingOptsMethodFor('_vanilli/stubs');
         server.post('_vanilli/stubs', function (request, response, next) {
             try {
                 response.send(200, addToRegistry(request));
@@ -148,7 +139,6 @@ exports.start = function (config) {
             return next();
         });
 
-        createCorsSupportingOptsMethodFor('_vanilli/verify');
         server.get('_vanilli/verify', function (request, response, next) {
             try {
                 response.send(200, { errors: stubRegistry.verifyExpectations() });
@@ -160,7 +150,6 @@ exports.start = function (config) {
             return next();
         });
 
-        createCorsSupportingOptsMethodFor('_vanilli/captures');
         server.get('_vanilli/captures/:captureId', function (request, response, next) {
             try {
                 var capture = stubRegistry.getCapture(request.params.captureId);

--- a/lib/vanilli/server.js
+++ b/lib/vanilli/server.js
@@ -13,8 +13,8 @@ exports.start = function (config) {
                     directory: config.static.root,
                     "default": config.static.default || "index.html"
                 }),
-                include: config.static.include,
-                exclude: config.static.exclude
+                include: config.static.include || [],
+                exclude: config.static.exclude || []
             };
 
             log.debug("Serving up static content with configuration", config.static);
@@ -148,8 +148,8 @@ exports.start = function (config) {
             return next();
         });
 
-        createCorsSupportingOptsMethodFor('_vanilli/stubs/verification');
-        server.get('_vanilli/stubs/verification', function (request, response, next) {
+        createCorsSupportingOptsMethodFor('_vanilli/verify');
+        server.get('_vanilli/verify', function (request, response, next) {
             try {
                 response.send(200, { errors: stubRegistry.verifyExpectations() });
 

--- a/lib/vanilli/server.js
+++ b/lib/vanilli/server.js
@@ -101,7 +101,78 @@ exports.start = function (config) {
             next();
         }
 
+        function addToRegistry(request) {
+            if (_.isArray(request.body)) {
+                return request.body.map(function (stub) {
+                    return stubRegistry.addStub(stub).id;
+                });
+            } else {
+                return [ stubRegistry.addStub(request.body).id ];
+            }
+        }
+
+        function createCorsSupportingOptsMethodFor(url) {
+            server.opts(url, function (request, response, next) {
+                response.send(200);
+                next();
+            });
+        }
+
         log.info("Vanilli Server started on port " + port + ".");
+
+        server.get('_vanilli/ping', function (request, response, next) {
+            response.send({ ping: "pong" });
+            return next();
+        });
+
+        createCorsSupportingOptsMethodFor('_vanilli/stubs');
+        server.del('_vanilli/stubs', function (request, response, next) {
+            stubRegistry.clear();
+            response.send(200);
+            next();
+        });
+
+        createCorsSupportingOptsMethodFor('_vanilli/stubs');
+        server.post('_vanilli/stubs', function (request, response, next) {
+            try {
+                response.send(200, addToRegistry(request));
+
+            } catch (e) {
+                response.send(400, e.message);
+            }
+
+            return next();
+        });
+
+        createCorsSupportingOptsMethodFor('_vanilli/stubs/verification');
+        server.get('_vanilli/stubs/verification', function (request, response, next) {
+            try {
+                response.send(200, { errors: stubRegistry.verifyExpectations() });
+
+            } catch (e) {
+                response.send(400, e.message);
+            }
+
+            return next();
+        });
+
+        createCorsSupportingOptsMethodFor('_vanilli/captures');
+        server.get('_vanilli/captures/:captureId', function (request, response, next) {
+            try {
+                var capture = stubRegistry.getCapture(request.params.captureId);
+
+                if (capture) {
+                    response.send(200, capture);
+                } else {
+                    response.send(404, "Not found");
+                }
+
+            } catch (e) {
+                response.send(400, e.message);
+            }
+
+            return next();
+        });
 
         server.get(/.*/, function (request, response, next) {
             function isRequestForStaticContent(request) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.1",
   "description": "Setup and serve stubs, fakes and expectations",
   "main": "./lib/vanilli.js",
+  "bin": "./bin/vanilli",
   "scripts": {
     "test": "node_modules/.bin/gulp"
   },
@@ -19,7 +20,7 @@
     "name": "Alistair Dutton"
   },
   "contributors": [
-      "Dan Scotton"
+    "Dan Scotton"
   ],
   "license": "BSD-3-Clause",
   "bugs": {
@@ -30,6 +31,7 @@
     "lodash": "2.4.1",
     "minimatch": "2.0.1",
     "node-uuid": "1.4.2",
+    "optimist": "0.6.1",
     "restify": "2.8.4"
   },
   "devDependencies": {

--- a/test/e2e/vanilli-test.js
+++ b/test/e2e/vanilli-test.js
@@ -42,6 +42,16 @@ describe('Vanilli', function () {
         vanilli.clear();
     });
 
+    it('listens on the configured port', function (done) {
+        client.get('/_vanilli/ping')
+            .end(function (err, res) {
+                expect(res).to.be.json;
+                expect(res).to.have.status(200);
+                expect(res.body.ping).to.equal("pong");
+                done();
+            });
+    });
+
     it('serves up the stub matching the incoming request', function (done) {
         vanilli.stub(
             vanilli.onGet("/another/url").respondWith(123),


### PR DESCRIPTION
This is to allow for bindings other than the default javascript ones (i.e. ruby).

This should just be a case of resurrecting the corresponding functionality from vanilli's past.