### PR TITLE
Proxy routes to static resources

### DIFF
--- a/lib/vanilli/server.js
+++ b/lib/vanilli/server.js
@@ -9,13 +9,20 @@ exports.start = function (config) {
     function createStaticServer(config) {
         if (config.static && config.static.root) {
             var serverConfig = {
-                serve: restify.serveStatic({
-                    directory: config.static.root,
-                    "default": config.static.default || "index.html"
+                "default" : config.static.default || "index.html",
+
+                include: (config.static.include || []).map(function includeProxyRoutes( resource ) {
+                    var isProxyRoute = _.isObject(resource);
+                    return isProxyRoute ? resource.path : resource;
                 }),
-                include: config.static.include || [],
-                exclude: config.static.exclude || []
+                exclude: config.static.exclude || [],
+                proxyRoutes: (config.static.include || []).filter(_.isObject)
             };
+
+            serverConfig.serve = restify.serveStatic({
+                directory: config.static.root,
+                "default": serverConfig.default
+            });
 
             log.debug("Serving up static content with configuration", config.static);
 
@@ -179,7 +186,19 @@ exports.start = function (config) {
                 }
             }
 
+            function proxyRouteToStatic(request) {
+                var matchedRoute = _.find(staticServer.proxyRoutes, function ( route ) {
+                        return minimatch( request.url, route.path );
+                    }) || {},
+                    routeTarget = matchedRoute.useDefault ? staticServer.default : matchedRoute.target;
+
+                if ( routeTarget ) {
+                    request.url = routeTarget;
+                }
+            }
+
             if (isRequestForStaticContent(request)) {
+                proxyRouteToStatic(request);
                 staticServer.serve(request, response, next);
                 log.info("SERVED request " + request.method + " " + request.url + " from static content.");
             } else {

--- a/test/e2e/static/foo.html
+++ b/test/e2e/static/foo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>foo</title>
+</head>
+<body>
+Foo
+</body>
+</html>

--- a/test/e2e/vanilli-test.js
+++ b/test/e2e/vanilli-test.js
@@ -4,7 +4,7 @@ var vanilli = require('../../lib/vanilli').init({
         static: {
             root: "test/e2e/static",
             "default": "something.html",
-            include: [ "**/*.html" ],
+            include: [ "**/*.html", { path: '/foo', target: 'foo.html' }, { path: '/bar', useDefault: true } ],
             exclude: [ "**/*.xxx" ]
         }
     }),
@@ -311,6 +311,22 @@ describe('Vanilli', function () {
 
         it('serves up default resource for no path', function (done) {
             client.get('')
+                .end(function (err, res) {
+                    expect(res).to.have.status(200);
+                    done();
+                });
+        });
+
+        it('serves up default resource proxy routes using default as target', function (done) {
+            client.get('/foo')
+                .end(function (err, res) {
+                    expect(res).to.have.status(200);
+                    done();
+                });
+        });
+
+        it('serves up specified target resource for proxy route if request meets criteria of static filter', function (done) {
+            client.get('/bar')
                 .end(function (err, res) {
                     expect(res).to.have.status(200);
                     done();


### PR DESCRIPTION
# Overview
The static includes can now handle proxying routes to a static resource. A common use case for single page applications with client side routing.

## Proxy route object shape
```JS
{
    path: {string}, // proxy route i.e /foo, /foo/*
    target: {string}, // proxy target, resource path i.e "path/to/target.html"
    useDefault: {boolean} // use static default resource, prioritised over target
}
```

## Example
```JS
vanilli.init({
    static: {
        "default": "page.html",
        include: [
            "**/*.html", // normal include
            { path: '/foo', target: 'foo.html' }, // proxy route to specified target
            { path: '/foo/**', target: 'foo-sub.html' }, // proxy wildcard route to specified target
            { path: '/bar', useDefault: true } // proxy route to default "page.html"
        ]
    }
    ...
});
```
