### PR TITLE
Refactor deserialisation of static includes from CLI options

### DIFF
--- a/bin/vanilli
+++ b/bin/vanilli
@@ -18,8 +18,8 @@ var path = require('path'),
     logLevel = argv.logLevel,
     staticRoot = argv.staticRoot,
     staticDefault = argv.staticDefault,
-    staticInclude = argv.staticInclude ? argv.staticInclude.split(",") : null,
-    staticExclude = argv.staticExclude ? argv.staticExclude.split(",") : null,
+    staticInclude = argv.staticInclude ? JSON.parse(argv.staticInclude) : null,
+    staticExclude = argv.staticExclude ? JSON.parse(argv.staticExclude) : null,
     dir = path.resolve(process.cwd(), 'node_modules', 'vanilli', 'lib');
 
 if (argv.version) {


### PR DESCRIPTION
in light of #31 & [vanilli-ruby update](https://github.com/mixradio/vanilli-ruby/pull/1), this update supports CLI usage.

## Usage example (if spawned in ruby)
### Before
- ruby spawns with: `vanilli --staticInclude=foo,bar,{:baz=>\"qux\"}`
    - results in `config.static.include = [ 'foo', 'bar', '{:baz=>"qux"}' ]`

### After
- ruby spawns with: `vanilli --staticInclude=[\"foo\",\"bar\",{\"baz\":\"qux\"}]`
    - results in `config.static.include = [ 'foo', 'bar', { baz: 'qux' } ]`