### PR TITLE
Improve `bodiesMatch` function

### DIFF
--- a/lib/vanilli/stub-registry.js
+++ b/lib/vanilli/stub-registry.js
@@ -150,6 +150,16 @@ exports.create = function (config) {
                 return (typeof thing === 'object') ? JSON.stringify(thing) : thing;
             }
 
+            function objectContains (container, containee) {
+                if (_.isObject(containee)) {
+                    return _.keys(containee).reduce(function (acc, key) {
+                        return acc && container.hasOwnProperty(key) && objectContains(container[key], containee[key]);
+                    }, true);
+                } else {
+                    return container === containee;
+                }
+            }
+
             function bufferAsString (thing) {
                 return (thing instanceof Buffer) ? thing.toString() : thing;
             }
@@ -167,7 +177,7 @@ exports.create = function (config) {
                         log.debug("REJECTED stub '" + stub.id + "' on body [Expected: '" + stub.criteria.body + "'; Actual: " + request.body + "]");
                         return false;
 
-                    } else if (objectAsString(stub.criteria.body) !== objectAsString(bufferAsString(request.body))) {
+                    } else if (!objectContains(bufferAsString(request.body), stub.criteria.body)) {
                         log.debug("REJECTED stub '" + stub.id + "' on body [Expected: '" + stub.criteria.body + "'; Actual: " + request.body + "]");
                         return false;
 

--- a/test/unit/stub-registry-test.js
+++ b/test/unit/stub-registry-test.js
@@ -436,13 +436,63 @@ describe('The stub registry', function () {
             expect(registry.findMatchFor({
                 path: path("my/url"),
                 method: 'GET',
-                body: JSON.stringify({
+                body: {
                     myfield: "myvalue"
-                }),
+                },
                 contentType: function () {
                     return "application/json";
                 }
             })).to.exist;
+        });
+
+        it('will match on stub with bodies despite extra fields', function () {
+            registry.addStub({
+                criteria: {
+                    url: dummyUrl,
+                    body: {
+                        my: { field: "value" }
+                    },
+                    contentType: "application/json"
+                },
+                response: dummyResponse
+            });
+
+            expect(registry.findMatchFor({
+                path: path("my/url"),
+                method: 'GET',
+                body: {
+                    my: { field: "value" },
+                    another: { field: "another" }
+                },
+                contentType: function () {
+                    return "application/json";
+                }
+            })).to.exist;
+        });
+
+        it('will NOT match on stub with bodies if not all fields present', function () {
+            registry.addStub({
+                criteria: {
+                    url: dummyUrl,
+                    body: {
+                        my: { field: "value" },
+                        another: { field: "another" }
+                    },
+                    contentType: "application/json"
+                },
+                response: dummyResponse
+            });
+
+            expect(registry.findMatchFor({
+                path: path("my/url"),
+                method: 'GET',
+                body: {
+                    my: { field: "value" }
+                },
+                contentType: function () {
+                    return "application/json";
+                }
+            })).to.not.exist;
         });
 
         it('will NOT match on stub specified with matching body but different content type', function () {


### PR DESCRIPTION
Rather than stringifying both bodies and then comparing strings, this PR improves the `bodiesMatch` function by comparing if an object contains another object.

Test case and implementation here: http://jsbin.com/dorekaqeya/edit?js,console